### PR TITLE
Update FrontendDependency for use with deps containing '/'

### DIFF
--- a/src/main/scala/SbtBowerPlugin.scala
+++ b/src/main/scala/SbtBowerPlugin.scala
@@ -129,8 +129,9 @@ class FrontendDependency( artifactName: String) {
 }
 
 class FrontendDependencyWithRevision( artifactName: String, revision: String ) extends FrontendDependency( artifactName ) {
+    require(artifactName.trim.nonEmpty, s"Artifact name may not be empty. Received: $artifactName")
     override def install = {
-      val safeArtifactName = artifactName.replaceAll("/","_")
+      val safeArtifactName = artifactName.split("/").last
       JField(safeArtifactName, s"$artifactName#$revision")
     }
 }

--- a/src/main/scala/SbtBowerPlugin.scala
+++ b/src/main/scala/SbtBowerPlugin.scala
@@ -129,5 +129,8 @@ class FrontendDependency( artifactName: String) {
 }
 
 class FrontendDependencyWithRevision( artifactName: String, revision: String ) extends FrontendDependency( artifactName ) {
-    override def install = JField(artifactName,JString(revision))
+    override def install = {
+      val safeArtifactName = artifactName.replaceAll("/","_")
+      JField(safeArtifactName, s"$artifactName#$revision")
+    }
 }


### PR DESCRIPTION
Some bower depeneencies contain '/' chars in the specifier.
FrontendDependency now converts all dependencies to use a safe form of
'key' -> 'artifactName#artifactVersion' rather than just 'artifactName'
-> 'artifactVersion'.

Example

  old: `'PolymerElements/paper-header-panel': '^1.0.0'`
  new: `'paper-header-panel': 'PolymerElements/paper-header-panel#^1.0.0'`
